### PR TITLE
Lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2026-03-16
+
+### Added
+- Grid blocks in `pipeline.toml`/`.yaml`: `[[grid]]` sections define parameter sweeps via Cartesian product. List-valued keys are expanded; scalar keys are fixed. Named grids can be referenced selectively from experiment blocks. Grids and experiments are crossed automatically when both are present.
+- Grid sweep example in `examples/sweep-example/` with full documentation in `docs/getting-started.md`.
+
+### Fixed
+- `get_parent()` now accepts an optional `sp_key` parameter, fixing silent breakage when a `DependencySpec` uses a non-default key.
+- `collect_params_with_parents` now raises `DependencyResolutionError` instead of a bare `LookupError` when a parent is missing, consistent with the rest of the library.
+
+### Added
+- `ActionSpec.dep_sp_key` property — returns `dependency.sp_key` if a dependency exists, otherwise `DEFAULT_PARENT_SP_KEY`. Centralises parent-key resolution across `collect`, `migrate`, and `row_utils`.
+- `RESERVED_DOC_KEYS` is now a public `frozenset` exported from `grubicy`, so callers can filter job document keys without reimplementing the list.
+
 ## [1.2.0] - 2026-02-26
 - Added pydantic as a dependency
 - Added the module `grubicy.typed` which provides helpers to automatically map the statepoint to a defined pydantic model

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -95,7 +95,94 @@ Notes:
   typically use `experiments:` (plural). grubicy accepts both `experiment` and
   `experiments` at the top level.
 
-## 1b) Minimal action scripts
+## 1b) Using grids
+
+Writing out every combination of parameters by hand gets tedious fast. A **grid**
+defines a reusable parameter base — a set of action params that get crossed with every
+experiment you add.
+
+### Defining grids
+
+Within a `[[grid]]` block, **list-valued keys are swept** (Cartesian product within
+the action) and **scalar keys are fixed**. Combinations across actions are also crossed:
+
+```toml
+[[grid]]
+name = "main"
+  [grid.s1]
+  p1 = [1, 2]      # swept: 2 values
+
+  [grid.s2]
+  p2 = [10, 20]    # swept: 2 values
+  seed = 42        # fixed: appears in all generated combos
+```
+
+Multiple `[[grid]]` blocks are independent. Their expansions are **concatenated** into
+the grid space (not crossed with each other). Use this to express dependent groups:
+
+```toml
+[[grid]]
+name = "low"
+  [grid.s1]
+  p1 = [1]
+  [grid.s2]
+  p2 = [1, 2, 3, 4]
+
+[[grid]]
+name = "high"
+  [grid.s1]
+  p1 = [2]
+  [grid.s2]
+  p2 = [5, 6, 7, 8]
+```
+
+### Crossing grids with experiments
+
+Experiments define variations that get **crossed against the grid space**. The total
+number of jobs is `grid_combos × experiments`:
+
+```toml
+# 8 grid combos (4 from "low", 4 from "high")
+
+[[experiment]]                        # crossed with all 8 combos → 8 jobs
+  [experiment.s3]
+  p3 = 0.1
+
+[[experiment]]                        # crossed with all 8 combos → 8 more jobs
+  [experiment.s3]
+  p3 = 0.2
+```
+
+Each resulting job merges grid params (s1, s2) with experiment params (s3). If an
+experiment defines a key also present in the grid, the experiment value takes
+precedence.
+
+### Selecting which grids an experiment applies to
+
+By default an experiment is crossed with **all** defined grids. Add a `grids` key to
+select only specific ones by name:
+
+```toml
+[[experiment]]                         # uses both "low" and "high" → 8 jobs
+  [experiment.s3]
+  p3 = 0.1
+
+[[experiment]]                         # uses only "low" → 4 jobs
+grids = ["low"]
+  [experiment.s3]
+  p3 = 0.2
+
+[[experiment]]                         # standalone: no grids applied → 1 job
+grids = []
+  [experiment.s1]
+  p1 = 99
+  [experiment.s3]
+  p3 = 0.5
+```
+
+A full runnable example lives in `examples/grid-example/`.
+
+## 1c) Minimal action scripts
 Place action scripts in `actions/`. They receive the job workspace directory from row.
 
 Root action (no parent):

--- a/examples/sweep-example/README.md
+++ b/examples/sweep-example/README.md
@@ -1,0 +1,47 @@
+Grid example (sweep-example)
+============================
+
+This example demonstrates the grid feature: a **named grid** defines a reusable
+parameter base, and each `[[experiment]]` block is crossed against it.
+
+## Pipeline structure
+
+```
+s1 (p1) → s2 (p2) → s3 (p3)
+```
+
+## Parameter space
+
+Two named grids express a dependent p1/p2 relationship:
+
+| grid | p1 | p2           | combos |
+|------|----|--------------|--------|
+| low  | 1  | 1, 2, 3, 4   | 4      |
+| high | 2  | 5, 6, 7, 8   | 4      |
+
+Four experiments vary p3 and optionally restrict which grids they apply to:
+
+| experiment | grids applied  | p3  | jobs generated |
+|------------|----------------|-----|----------------|
+| A          | all (8 combos) | 0.1 | 8              |
+| B          | all (8 combos) | 0.2 | 8              |
+| C          | "low" only (4) | 0.3 | 4              |
+| D          | none (standalone) | 0.0 | 1           |
+
+**Total s3 jobs: 21** (plus the shared s1/s2 upstream jobs).
+
+## Running
+
+```bash
+# 1) Materialize jobs
+uv run grubicy prepare pipeline.toml
+
+# 2) Submit ready actions (or use row directly)
+grubicy submit pipeline.toml --dry-run
+grubicy submit pipeline.toml
+
+# 3) Collect results
+uv run python collect_results.py
+```
+
+You should see a 21-row table in the output and a `results_table.csv` file.

--- a/examples/sweep-example/actions/s1.py
+++ b/examples/sweep-example/actions/s1.py
@@ -1,0 +1,27 @@
+import json
+from pathlib import Path
+
+import signac
+
+
+def main(directory: str):
+    project = signac.get_project()
+    job = project.open_job(id=Path(directory).name)
+
+    assert job.sp["action"] == "s1"
+    p1 = job.sp["p1"]
+
+    value = p1 * p1
+
+    out_path = Path(job.fn("s1/out.json"))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({"p1": p1, "value": value}, f)
+
+    job.doc["s1_value"] = value
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1])

--- a/examples/sweep-example/actions/s2.py
+++ b/examples/sweep-example/actions/s2.py
@@ -1,0 +1,35 @@
+import json
+from pathlib import Path
+
+from grubicy import get_parent, open_job_from_directory, parent_path
+from grubicy.helpers import parent_product_exists
+
+
+def main(directory: str):
+    job = open_job_from_directory(directory)
+
+    assert job.sp["action"] == "s2"
+    p2 = job.sp["p2"]
+
+    if not parent_product_exists(job, "s1/out.json"):
+        return
+    with open(parent_path(job) / "s1/out.json", "r", encoding="utf-8") as f:
+        s1 = json.load(f)
+
+    value2 = s1["value"] + p2
+
+    out_path = Path(job.fn("s2/out.json"))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(
+        json.dumps({"p1": s1["p1"], "p2": p2, "value2": value2}), encoding="utf-8"
+    )
+
+    parent = get_parent(job)
+    job.doc["s2_value2"] = value2
+    job.doc["parent_s1_id"] = parent.id
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1])

--- a/examples/sweep-example/actions/s3.py
+++ b/examples/sweep-example/actions/s3.py
@@ -1,0 +1,33 @@
+import json
+from pathlib import Path
+
+import signac
+from grubicy import get_parent
+
+
+def main(directory: str):
+    project = signac.get_project()
+    job = project.open_job(id=Path(directory).name)
+
+    assert job.sp["action"] == "s3"
+    p3 = job.sp["p3"]
+
+    parent = get_parent(job)
+    with open(Path(parent.fn("s2/out.json")), "r", encoding="utf-8") as f:
+        s2 = json.load(f)
+
+    value3 = s2["value2"] * p3
+
+    out_path = Path(job.fn("s3/out.json"))
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump({"p1": s2["p1"], "p2": s2["p2"], "p3": p3, "value3": value3}, f)
+
+    job.doc["s3_value3"] = value3
+    job.doc["parent_s2_id"] = parent.id
+
+
+if __name__ == "__main__":
+    import sys
+
+    main(sys.argv[1])

--- a/examples/sweep-example/collect_results.py
+++ b/examples/sweep-example/collect_results.py
@@ -1,0 +1,49 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import signac
+from grubicy import get_parent
+
+
+def read_json(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def main():
+    project = signac.get_project()
+
+    rows = []
+    for j3 in project.find_jobs({"action": "s3"}):
+        j2 = get_parent(j3)
+        j1 = get_parent(j2)
+
+        s1_out = read_json(Path(j1.fn("s1/out.json")))
+        s2_out = read_json(Path(j2.fn("s2/out.json")))
+        s3_out = read_json(Path(j3.fn("s3/out.json")))
+
+        rows.append(
+            {
+                "s1_job_id": j1.id,
+                "s2_job_id": j2.id,
+                "s3_job_id": j3.id,
+                "p1": j1.sp.get("p1"),
+                "p2": j2.sp.get("p2"),
+                "p3": j3.sp.get("p3"),
+                "s1_value": s1_out.get("value", j1.doc.get("s1_value")),
+                "s2_value2": s2_out.get("value2", j2.doc.get("s2_value2")),
+                "s3_value3": s3_out.get("value3", j3.doc.get("s3_value3")),
+            }
+        )
+
+    df = pd.DataFrame(rows).sort_values(["p1", "p2", "p3"]).reset_index(drop=True)
+    df.to_csv("results_table.csv", index=False)
+
+    print(df)
+    print(f"\nWrote results_table.csv with {len(df)} rows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/sweep-example/pipeline.toml
+++ b/examples/sweep-example/pipeline.toml
@@ -1,0 +1,73 @@
+[workspace]
+value_file = "signac_statepoint.json"
+
+[[actions]]
+name = "s1"
+sp_keys = ["p1"]
+outputs = ["s1/out.json"]
+
+[[actions]]
+name = "s2"
+sp_keys = ["p2"]
+deps = { action = "s1", sp_key = "parent_action" }
+outputs = ["s2/out.json"]
+
+[[actions]]
+name = "s3"
+sp_keys = ["p3"]
+deps = { action = "s2", sp_key = "parent_action" }
+outputs = ["s3/out.json"]
+
+# ---------------------------------------------------------------------------
+# Grid space: two named groups expressing a dependent p1/p2 relationship.
+# "low":  p1=1 paired with p2 in {1,2,3,4}  → 4 combos
+# "high": p1=2 paired with p2 in {5,6,7,8}  → 4 combos
+# Total grid space: 8 combos.
+# ---------------------------------------------------------------------------
+
+[[grid]]
+name = "low"
+  [grid.s1]
+  p1 = [1]
+  [grid.s2]
+  p2 = [1, 2, 3, 4]
+
+[[grid]]
+name = "high"
+  [grid.s1]
+  p1 = [2]
+  [grid.s2]
+  p2 = [5, 6, 7, 8]
+
+# ---------------------------------------------------------------------------
+# Experiments: each is crossed with (a subset of) the grid space.
+#
+# exp A — all 8 grid combos × p3=0.1  →  8 jobs
+# exp B — all 8 grid combos × p3=0.2  →  8 jobs
+# exp C — only "low" (4 combos) × p3=0.3  →  4 jobs
+# exp D — standalone (no grids), fixed p1/p2/p3  →  1 job
+#
+# Total: 21 jobs for s3 (plus the shared upstream s1/s2 jobs).
+# ---------------------------------------------------------------------------
+
+[[experiment]]
+  [experiment.s3]
+  p3 = 0.1
+
+[[experiment]]
+  [experiment.s3]
+  p3 = 0.2
+
+[[experiment]]
+grids = ["low"]
+  [experiment.s3]
+  p3 = 0.3
+
+[[experiment]]
+grids = []
+  [experiment.s1]
+  p1 = 0
+  [experiment.s2]
+  p2 = 0
+  [experiment.s3]
+  p3 = 0.0

--- a/grubicy/__init__.py
+++ b/grubicy/__init__.py
@@ -34,7 +34,7 @@ from .migrate import (
     execute_migration,
     plan_migration,
 )
-from .collect import CollectedRow, collect_params_with_parents
+from .collect import CollectedRow, RESERVED_DOC_KEYS, collect_params_with_parents
 
 __all__ = [
     "ActionSpec",
@@ -59,6 +59,7 @@ __all__ = [
     "plan_migration",
     "execute_migration",
     "CollectedRow",
+    "RESERVED_DOC_KEYS",
     "collect_params_with_parents",
     "load_spec",
     # grubicy.typed — opt-in typed parameter bindings

--- a/grubicy/collect.py
+++ b/grubicy/collect.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Mapping, Sequence
 
 import signac
 
-from .spec import ActionSpec, WorkflowSpec
+from .spec import ActionSpec, DEFAULT_PARENT_SP_KEY, WorkflowSpec
 import msgspec
 
 
@@ -77,7 +77,7 @@ class ParamCollector:
             dep_key = (
                 child_spec.dependency.sp_key
                 if child_spec.dependency
-                else "parent_action"
+                else DEFAULT_PARENT_SP_KEY
             )
             child_job = job_map[child_name]
             parent_id = child_job.sp.get(dep_key)

--- a/grubicy/collect.py
+++ b/grubicy/collect.py
@@ -6,7 +6,8 @@ from typing import Dict, List, Mapping, Sequence
 
 import signac
 
-from .spec import ActionSpec, DEFAULT_PARENT_SP_KEY, WorkflowSpec
+from .helpers import DependencyResolutionError
+from .spec import ActionSpec, WorkflowSpec
 import msgspec
 
 
@@ -16,7 +17,7 @@ class CollectedRow(msgspec.Struct):
     data: Dict[str, object]
 
 
-_RESERVED_DOC_KEYS = {"deps_meta", "pipeline", "pipeline_meta"}
+RESERVED_DOC_KEYS: frozenset[str] = frozenset({"deps_meta", "pipeline", "pipeline_meta"})
 
 
 class ParamCollector:
@@ -45,7 +46,7 @@ class ParamCollector:
             if job_map is None:
                 if self.missing_ok:
                     continue
-                raise LookupError(
+                raise DependencyResolutionError(
                     f"Missing parent for job {leaf.id} when collecting {target_action}"
                 )
 
@@ -74,11 +75,7 @@ class ParamCollector:
             child_name = chain[idx]
             parent_name = chain[idx - 1]
             child_spec = self._action_map[child_name]
-            dep_key = (
-                child_spec.dependency.sp_key
-                if child_spec.dependency
-                else DEFAULT_PARENT_SP_KEY
-            )
+            dep_key = child_spec.dep_sp_key
             child_job = job_map[child_name]
             parent_id = child_job.sp.get(dep_key)
             if parent_id is None:
@@ -104,7 +101,7 @@ class ParamCollector:
                     row[f"{name}.{key}"] = part.sp[key]
             if self.include_doc:
                 for dkey, dval in part.doc.items():
-                    if dkey in _RESERVED_DOC_KEYS:
+                    if dkey in RESERVED_DOC_KEYS:
                         continue
                     row[f"{name}.doc.{dkey}"] = dval
 

--- a/grubicy/helpers.py
+++ b/grubicy/helpers.py
@@ -7,9 +7,21 @@ from typing import Any, Iterator
 
 import signac
 
+from .spec import ACTION_SP_KEY, DEFAULT_PARENT_SP_KEY
+
 
 class DependencyResolutionError(Exception):
     """Raised when a job's parent cannot be resolved."""
+
+
+def write_dependency_metadata(job: signac.Job, parent_job: signac.Job) -> None:
+    """Update ``job.doc['deps_meta']`` with parent job info."""
+    deps_meta = dict(job.doc.get("deps_meta", {}))
+    deps_meta[parent_job.sp.get(ACTION_SP_KEY, parent_job.id)] = {
+        "job_id": parent_job.id,
+        "statepoint": dict(parent_job.sp),
+    }
+    job.doc["deps_meta"] = deps_meta
 
 
 def get_parent(job: signac.Job) -> signac.Job:
@@ -21,7 +33,7 @@ def get_parent(job: signac.Job) -> signac.Job:
         If the job does not declare a parent or the referenced job cannot be opened.
     """
 
-    key = "parent_action"
+    key = DEFAULT_PARENT_SP_KEY
     if key not in job.sp:
         raise DependencyResolutionError(f"Job {job.id} has no '{key}' state point key")
     parent_id = job.sp[key]

--- a/grubicy/helpers.py
+++ b/grubicy/helpers.py
@@ -24,8 +24,17 @@ def write_dependency_metadata(job: signac.Job, parent_job: signac.Job) -> None:
     job.doc["deps_meta"] = deps_meta
 
 
-def get_parent(job: signac.Job) -> signac.Job:
-    """Return the parent job referenced by ``parent_action`` in the state point.
+def get_parent(job: signac.Job, sp_key: str = DEFAULT_PARENT_SP_KEY) -> signac.Job:
+    """Return the parent job referenced by *sp_key* in the state point.
+
+    Parameters
+    ----------
+    job
+        The child job whose parent should be resolved.
+    sp_key
+        State-point key that holds the parent job ID.  Defaults to
+        ``DEFAULT_PARENT_SP_KEY`` (``"parent_action"``); pass
+        ``action.dep_sp_key`` when using a custom dependency key.
 
     Raises
     ------
@@ -33,10 +42,9 @@ def get_parent(job: signac.Job) -> signac.Job:
         If the job does not declare a parent or the referenced job cannot be opened.
     """
 
-    key = DEFAULT_PARENT_SP_KEY
-    if key not in job.sp:
-        raise DependencyResolutionError(f"Job {job.id} has no '{key}' state point key")
-    parent_id = job.sp[key]
+    if sp_key not in job.sp:
+        raise DependencyResolutionError(f"Job {job.id} has no '{sp_key}' state point key")
+    parent_id = job.sp[sp_key]
     project = job.project
     try:
         return project.open_job(id=str(parent_id))

--- a/grubicy/materialize.py
+++ b/grubicy/materialize.py
@@ -7,6 +7,7 @@ from typing import Dict, Iterable, List, Mapping, Optional
 
 import signac
 
+from .helpers import write_dependency_metadata
 from .spec import ActionSpec, ConfigValidationError, WorkflowSpec
 import msgspec
 
@@ -83,7 +84,7 @@ class Materializer:
 
             created = self._init_job(job)
             if parent_job:
-                self._write_dependency_metadata(job, parent_job)
+                write_dependency_metadata(job, parent_job)
 
             parent_jobs[action.name] = job
             if created:
@@ -119,15 +120,6 @@ class Materializer:
         created = not Path(job.path).exists()
         job.init()
         return created
-
-    @staticmethod
-    def _write_dependency_metadata(job: signac.Job, parent_job: signac.Job) -> None:
-        deps_meta = dict(job.doc.get("deps_meta", {}))
-        deps_meta[parent_job.sp.get("action", parent_job.id)] = {
-            "job_id": parent_job.id,
-            "statepoint": dict(parent_job.sp),
-        }
-        job.doc["deps_meta"] = deps_meta
 
     def _resolve_parent(
         self,

--- a/grubicy/migrate.py
+++ b/grubicy/migrate.py
@@ -12,6 +12,7 @@ from filelock import FileLock, Timeout
 import msgspec
 import signac
 
+from .helpers import write_dependency_metadata
 from .spec import ConfigValidationError, WorkflowSpec
 
 StatePoint = Dict[str, Any]
@@ -303,12 +304,7 @@ class MigrationExecutor:
 
     def _update_deps_meta(self, job: signac.Job, new_parent_id: str) -> None:
         parent_job = self.project.open_job(id=new_parent_id)
-        deps_meta = dict(job.doc.get("deps_meta", {}))
-        deps_meta[parent_job.sp.get("action", parent_job.id)] = {
-            "job_id": parent_job.id,
-            "statepoint": dict(parent_job.sp),
-        }
-        job.doc["deps_meta"] = deps_meta
+        write_dependency_metadata(job, parent_job)
 
     def _increment_updated(self, action_name: str) -> None:
         self.updated_counts[action_name] += 1

--- a/grubicy/migrate.py
+++ b/grubicy/migrate.py
@@ -275,7 +275,7 @@ class MigrationExecutor:
             current_map: Dict[str, str] = self.mapping_by_action.get(action.name, {})
 
             for job in self.project.find_jobs({"action": action.name}):
-                dep_key = action.dependency.sp_key
+                dep_key = action.dep_sp_key
                 parent_id = job.sp.get(dep_key)
                 if parent_id not in parent_map:
                     continue

--- a/grubicy/row_utils.py
+++ b/grubicy/row_utils.py
@@ -102,7 +102,7 @@ def _job_is_ready(job: signac.Job, action, status: RowStatus) -> bool:
         return True
 
     try:
-        parent_job = get_parent(job)
+        parent_job = get_parent(job, dep.sp_key)
     except DependencyResolutionError:
         return False
     return parent_job.id in status.completed

--- a/grubicy/spec.py
+++ b/grubicy/spec.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import tomllib
 from collections import deque
 from dataclasses import dataclass
+from itertools import product as iproduct
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 
 class ConfigValidationError(Exception):
@@ -118,6 +119,165 @@ class WorkspaceSpec:
         return WorkspaceSpec(value_file=str(value_file))
 
 
+def _expand_grid(
+    grid: Dict[str, Dict[str, Any]]
+) -> List[Dict[str, Dict[str, Any]]]:
+    """Expand a grid block into experiments via Cartesian product.
+
+    Within each action, list-valued keys are swept and scalar keys are fixed.
+    The per-action combinations are then crossed with each other.
+    """
+    action_names = list(grid.keys())
+    action_combos: List[List[Dict[str, Any]]] = []
+
+    for action_name in action_names:
+        params = grid[action_name] or {}
+        list_keys = [k for k, v in params.items() if isinstance(v, list)]
+        scalar_params = {k: v for k, v in params.items() if not isinstance(v, list)}
+
+        if list_keys:
+            combos = [
+                {**scalar_params, **dict(zip(list_keys, vals))}
+                for vals in iproduct(*[params[k] for k in list_keys])
+            ]
+        else:
+            combos = [scalar_params]
+
+        action_combos.append(combos)
+
+    return [
+        {action_names[i]: combo for i, combo in enumerate(cross)}
+        for cross in iproduct(*action_combos)
+    ]
+
+
+def _cross_grid_with_experiment(
+    grid_space: List[Dict[str, Dict[str, Any]]],
+    experiment: Dict[str, Dict[str, Any]],
+) -> List[Dict[str, Dict[str, Any]]]:
+    """Cross a grid space with a single experiment.
+
+    For each grid combo, the experiment's per-action params are merged in.
+    Experiment params take precedence over grid params for the same action/key.
+    """
+    result = []
+    for grid_exp in grid_space:
+        merged: Dict[str, Dict[str, Any]] = {}
+        for action, params in grid_exp.items():
+            merged[action] = dict(params)
+        for action, params in experiment.items():
+            if action in merged:
+                merged[action] = {**merged[action], **params}
+            else:
+                merged[action] = dict(params)
+        result.append(merged)
+    return result
+
+
+def _parse_grid_blocks(
+    raw_grids: List[Any],
+) -> List[Tuple[Optional[str], List[Dict[str, Dict[str, Any]]]]]:
+    """Parse and expand raw grid block entries.
+
+    Returns a list of (name | None, expanded-combos) tuples.
+    """
+    result: List[Tuple[Optional[str], List[Dict[str, Dict[str, Any]]]]] = []
+    for idx, grid in enumerate(raw_grids):
+        if not isinstance(grid, dict):
+            raise ConfigValidationError(f"Grid #{idx} must be a table/object")
+        name = str(grid["name"]) if "name" in grid else None
+        params = {k: v or {} for k, v in grid.items() if k != "name"}
+        result.append((name, _expand_grid(params)))
+    return result
+
+
+def _parse_experiment_blocks(
+    raw_experiments: List[Any],
+) -> List[Tuple[Optional[List[str]], Dict[str, Dict[str, Any]]]]:
+    """Parse raw experiment block entries.
+
+    Returns a list of (grid_filter | None, params) tuples.
+
+    grid_filter meanings:
+      None  → apply all grids (default)
+      []    → apply no grids (standalone experiment)
+      [...] → apply only the named grids
+    """
+    result: List[Tuple[Optional[List[str]], Dict[str, Dict[str, Any]]]] = []
+    for idx, exp in enumerate(raw_experiments):
+        if not isinstance(exp, dict):
+            raise ConfigValidationError(f"Experiment #{idx} must be a table/object")
+        raw_filter = exp.get("grids")
+        if raw_filter is not None and not isinstance(raw_filter, list):
+            raise ConfigValidationError(
+                f"Experiment #{idx}: 'grids' must be a list of grid names"
+            )
+        grid_filter: Optional[List[str]] = (
+            None if raw_filter is None else [str(s) for s in raw_filter]
+        )
+        exp_params = {k: v or {} for k, v in exp.items() if k != "grids"}
+        result.append((grid_filter, exp_params))
+    return result
+
+
+def _validate_grid_actions(
+    grid_groups: List[Tuple[Optional[str], List[Dict[str, Dict[str, Any]]]]],
+    action_names: Set[str],
+) -> None:
+    """Raise if any grid block references an action that was not defined."""
+    for name, combos in grid_groups:
+        label = f'Grid "{name}"' if name else "Unnamed grid"
+        for combo in combos:
+            for key in combo:
+                if key not in action_names:
+                    raise ConfigValidationError(
+                        f"{label} references unknown action '{key}'"
+                    )
+
+
+def _validate_grid_references(
+    parsed_experiments: List[Tuple[Optional[List[str]], Any]],
+    all_grid_names: Set[str],
+) -> None:
+    """Raise if any experiment references a grid name that was not defined."""
+    for idx, (grid_filter, _) in enumerate(parsed_experiments):
+        if grid_filter:
+            for ref in grid_filter:
+                if ref not in all_grid_names:
+                    raise ConfigValidationError(
+                        f"Experiment #{idx} references unknown grid '{ref}'"
+                    )
+
+
+def _combine_grids_and_experiments(
+    grid_groups: List[Tuple[Optional[str], List[Dict[str, Dict[str, Any]]]]],
+    parsed_experiments: List[Tuple[Optional[List[str]], Dict[str, Dict[str, Any]]]],
+) -> List[Dict[str, Dict[str, Any]]]:
+    """Combine grid expansions with experiments into the final experiment list."""
+    if not grid_groups:
+        # No grids: each experiment is standalone
+        return [params for _, params in parsed_experiments]
+    if not parsed_experiments:
+        # No experiments: grid expansions are the result
+        return [exp for _, exps in grid_groups for exp in exps]
+    # Both present: cross each experiment with its applicable grid space
+    experiments: List[Dict[str, Dict[str, Any]]] = []
+    for grid_filter, exp_params in parsed_experiments:
+        if grid_filter is None:
+            applicable = [exp for _, exps in grid_groups for exp in exps]
+        elif not grid_filter:
+            applicable = [{}]  # identity — standalone experiment
+        else:
+            applicable = [
+                exp
+                for name, exps in grid_groups
+                if name in grid_filter
+                for exp in exps
+            ]
+        experiments.extend(_cross_grid_with_experiment(applicable, exp_params))
+    return experiments
+
+
 class WorkflowSpec:
     """Parsed configuration for a workflow.
 
@@ -137,6 +297,7 @@ class WorkflowSpec:
         if len(self._action_index) != len(actions):
             raise ConfigValidationError("Action names must be unique")
         self._validate_dependencies()
+        self._validate_experiments()
 
     @staticmethod
     def load(path: str | Path) -> "WorkflowSpec":
@@ -168,24 +329,36 @@ class WorkflowSpec:
         if not isinstance(raw_actions, Iterable):
             raise ConfigValidationError("'actions' must be a list of action tables")
 
-        actions = [ActionSpec.from_mapping(entry) for entry in raw_actions]
-
+        actions = [ActionSpec.from_mapping(e) for e in raw_actions]
         workspace = WorkspaceSpec.from_mapping(data.get("workspace", {}))
 
+        raw_grids = data.get("grids") or data.get("grid") or []
+        if raw_grids and not isinstance(raw_grids, list):
+            raise ConfigValidationError("'grids' must be a list")
+        grid_groups = _parse_grid_blocks(raw_grids)
+        action_names = {a.name for a in actions}
+        _validate_grid_actions(grid_groups, action_names)
+
         raw_experiments = data.get("experiments") or data.get("experiment") or []
-        if raw_experiments and not isinstance(raw_experiments, Iterable):
+        if raw_experiments and not isinstance(raw_experiments, list):
             raise ConfigValidationError("'experiments' must be a list")
+        parsed_experiments = _parse_experiment_blocks(raw_experiments)
 
-        experiments: List[Dict[str, Dict[str, Any]]] = []
-        for idx, exp in enumerate(raw_experiments):
-            if not isinstance(exp, dict):
-                raise ConfigValidationError(f"Experiment #{idx} must be a table/object")
-            # Each key is an action name mapping to params.
-            experiments.append({k: v or {} for k, v in exp.items()})
-
-        return WorkflowSpec(
-            actions=actions, experiments=experiments, workspace=workspace
+        _validate_grid_references(
+            parsed_experiments, {n for n, _ in grid_groups if n is not None}
         )
+        experiments = _combine_grids_and_experiments(grid_groups, parsed_experiments)
+
+        return WorkflowSpec(actions=actions, experiments=experiments, workspace=workspace)
+
+    def _validate_experiments(self) -> None:
+        action_names = set(self._action_index)
+        for idx, exp in enumerate(self._experiments):
+            for key in exp:
+                if key not in action_names:
+                    raise ConfigValidationError(
+                        f"Experiment #{idx} references unknown action '{key}'"
+                    )
 
     def _validate_dependencies(self) -> None:
         action_names = {a.name for a in self.actions}

--- a/grubicy/spec.py
+++ b/grubicy/spec.py
@@ -14,6 +14,11 @@ class ConfigValidationError(Exception):
     """Raised when a configuration file fails validation."""
 
 
+# Reserved state-point keys managed by the framework
+ACTION_SP_KEY: str = "action"
+DEFAULT_PARENT_SP_KEY: str = "parent_action"
+
+
 @dataclass(frozen=True)
 class DependencySpec:
     """Represents a single parent dependency for an action.
@@ -27,7 +32,7 @@ class DependencySpec:
     """
 
     action: str
-    sp_key: str = "parent_action"
+    sp_key: str = DEFAULT_PARENT_SP_KEY
 
 
 @dataclass(frozen=True)
@@ -81,7 +86,7 @@ class ActionSpec:
                 raise ConfigValidationError(
                     "deps.action is required when specifying a dependency"
                 )
-            sp_key = raw_dep.get("sp_key", "parent_action")
+            sp_key = raw_dep.get("sp_key", DEFAULT_PARENT_SP_KEY)
             dependency = DependencySpec(action=str(dep_action), sp_key=str(sp_key))
 
         return ActionSpec(

--- a/grubicy/spec.py
+++ b/grubicy/spec.py
@@ -45,6 +45,11 @@ class ActionSpec:
     outputs: List[str] | None = None
     runner: Optional[str] = None
 
+    @property
+    def dep_sp_key(self) -> str:
+        """SP key used to store this action's parent job ID."""
+        return self.dependency.sp_key if self.dependency else DEFAULT_PARENT_SP_KEY
+
     @staticmethod
     def from_mapping(data: Dict[str, Any]) -> "ActionSpec":
         """Create an :class:`ActionSpec` from a mapping.

--- a/grubicy/typed/runtime.py
+++ b/grubicy/typed/runtime.py
@@ -8,9 +8,10 @@ from pydantic import BaseModel, ValidationError
 
 from .bindings import WorkflowBindings
 from .errors import ActionParamsNotFoundError, TypedParamsValidationError
+from grubicy.spec import ACTION_SP_KEY, DEFAULT_PARENT_SP_KEY
 
 # Keys injected by grubicy's materialiser that are not user-defined params.
-_RESERVED_SP_KEYS: frozenset[str] = frozenset({"action", "parent_action"})
+_RESERVED_SP_KEYS: frozenset[str] = frozenset({ACTION_SP_KEY, DEFAULT_PARENT_SP_KEY})
 
 
 def _extract_action_raw_params(job: Any, action: str) -> dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "grubicy"
-version = "1.2.0"
+version = "1.3.0"
 description = "Config-driven helpers for signac workflows with explicit dependencies and migrations"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/tests/test_collect.py
+++ b/tests/test_collect.py
@@ -1,6 +1,7 @@
 import pytest
 import signac
 
+from grubicy import DependencyResolutionError
 from grubicy.collect import collect_params_with_parents
 from grubicy.materialize import materialize
 from grubicy.spec import WorkflowSpec
@@ -56,7 +57,7 @@ def test_collect_raises_when_parent_missing(tmp_path, monkeypatch):
     job = project.open_job({"action": "s2", "p2": 2})
     job.init()
 
-    with pytest.raises(LookupError):
+    with pytest.raises(DependencyResolutionError):
         collect_params_with_parents(spec, project, "s2", include_doc=False)
 
 

--- a/tests/test_helper_utils.py
+++ b/tests/test_helper_utils.py
@@ -49,6 +49,19 @@ def test_get_parent_raises_when_no_parent_key(tmp_path, monkeypatch):
         get_parent(job)
 
 
+def test_get_parent_with_custom_sp_key(tmp_path, monkeypatch):
+    """get_parent resolves a parent stored under a non-default SP key."""
+    monkeypatch.chdir(tmp_path)
+    project = signac.init_project("helpers")
+
+    parent = project.open_job({"action": "s1", "p1": 1})
+    parent.init()
+    child = project.open_job({"action": "s2", "p2": 3, "parent_train": parent.id})
+    child.init()
+
+    assert get_parent(child, sp_key="parent_train").id == parent.id
+
+
 def test_get_parent_raises_when_parent_id_is_stale(tmp_path, monkeypatch):
     """get_parent raises DependencyResolutionError when parent_action ID doesn't exist."""
     monkeypatch.chdir(tmp_path)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -1,6 +1,6 @@
 import pytest
 
-from grubicy.spec import ConfigValidationError, WorkflowSpec
+from grubicy.spec import ActionSpec, ConfigValidationError, DependencySpec, WorkflowSpec
 
 
 def test_topological_order_and_experiments():
@@ -177,6 +177,17 @@ def test_experiment_unknown_action_raises():
                 "experiment": [{"ghost": {"p1": 1}}],
             }
         )
+
+
+def test_dep_sp_key_returns_custom_key():
+    dep = DependencySpec(action="s1", sp_key="parent_train")
+    action = ActionSpec(name="s2", sp_keys=["p2"], dependency=dep)
+    assert action.dep_sp_key == "parent_train"
+
+
+def test_dep_sp_key_returns_default_for_root_action():
+    action = ActionSpec(name="s1", sp_keys=["p1"])
+    assert action.dep_sp_key == "parent_action"
 
 
 def test_cycle_detection_raises():

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -24,6 +24,161 @@ def test_topological_order_and_experiments():
     assert spec.experiments[0]["s1"]["p1"] == 1
 
 
+def test_grid_cartesian_product():
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [
+                {"name": "s1", "sp_keys": ["p1"]},
+                {"name": "s2", "sp_keys": ["p2"], "deps": {"action": "s1"}},
+            ],
+            "grid": [{"s1": {"p1": [1, 2, 3]}, "s2": {"p2": [10, 20]}}],
+        }
+    )
+
+    exps = spec.experiments
+    assert len(exps) == 6
+    pairs = {(e["s1"]["p1"], e["s2"]["p2"]) for e in exps}
+    assert pairs == {(1, 10), (1, 20), (2, 10), (2, 20), (3, 10), (3, 20)}
+
+
+def test_grid_scalar_params_fixed():
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [{"name": "s1", "sp_keys": ["p1", "fixed"]}],
+            "grid": [{"s1": {"p1": [1, 2], "fixed": "x"}}],
+        }
+    )
+
+    exps = spec.experiments
+    assert len(exps) == 2
+    assert all(e["s1"]["fixed"] == "x" for e in exps)
+    assert {e["s1"]["p1"] for e in exps} == {1, 2}
+
+
+def test_grid_multiple_blocks_concatenated():
+    # Dependent case: p1=1 allows p2=[10,20], p1=2 allows p2=[30]
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [
+                {"name": "s1", "sp_keys": ["p1"]},
+                {"name": "s2", "sp_keys": ["p2"], "deps": {"action": "s1"}},
+            ],
+            "grid": [
+                {"s1": {"p1": [1]}, "s2": {"p2": [10, 20]}},
+                {"s1": {"p1": [2]}, "s2": {"p2": [30]}},
+            ],
+        }
+    )
+
+    exps = spec.experiments
+    assert len(exps) == 3
+    pairs = {(e["s1"]["p1"], e["s2"]["p2"]) for e in exps}
+    assert pairs == {(1, 10), (1, 20), (2, 30)}
+
+
+def test_grid_and_experiment_cross_product():
+    # Grid covers s1+s2; experiments vary s3 — total = grid_combos × experiments
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [
+                {"name": "s1", "sp_keys": ["p1"]},
+                {"name": "s2", "sp_keys": ["p2"], "deps": {"action": "s1"}},
+                {"name": "s3", "sp_keys": ["p3"], "deps": {"action": "s2"}},
+            ],
+            "grid": [{"s1": {"p1": [1, 2]}, "s2": {"p2": [10, 20]}}],
+            "experiment": [{"s3": {"p3": 0.1}}, {"s3": {"p3": 0.2}}],
+        }
+    )
+
+    # 2 p1 × 2 p2 = 4 grid combos × 2 experiments = 8 total
+    assert len(spec.experiments) == 8
+    assert {e["s3"]["p3"] for e in spec.experiments} == {0.1, 0.2}
+    assert {e["s1"]["p1"] for e in spec.experiments} == {1, 2}
+    assert {e["s2"]["p2"] for e in spec.experiments} == {10, 20}
+
+
+def test_experiment_applies_named_grids_only():
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [
+                {"name": "s1", "sp_keys": ["p1"]},
+                {"name": "s2", "sp_keys": ["p2"], "deps": {"action": "s1"}},
+                {"name": "s3", "sp_keys": ["p3"], "deps": {"action": "s2"}},
+            ],
+            "grid": [
+                {"name": "low", "s1": {"p1": [1]}, "s2": {"p2": [1, 2, 3, 4]}},
+                {"name": "high", "s1": {"p1": [2]}, "s2": {"p2": [5, 6, 7, 8]}},
+            ],
+            "experiment": [
+                {"s3": {"p3": 1}},                   # all grids → 8 combos
+                {"grids": ["low"], "s3": {"p3": 2}},  # only "low" → 4 combos
+            ],
+        }
+    )
+
+    assert len(spec.experiments) == 12
+    # p3=1 experiments all come from both grids
+    p3_1 = [e for e in spec.experiments if e["s3"]["p3"] == 1]
+    assert len(p3_1) == 8
+    assert {e["s1"]["p1"] for e in p3_1} == {1, 2}
+    # p3=2 experiments only come from "low"
+    p3_2 = [e for e in spec.experiments if e["s3"]["p3"] == 2]
+    assert len(p3_2) == 4
+    assert {e["s1"]["p1"] for e in p3_2} == {1}
+
+
+def test_experiment_opts_out_of_grids():
+    spec = WorkflowSpec.from_mapping(
+        {
+            "actions": [
+                {"name": "s1", "sp_keys": ["p1"]},
+                {"name": "s2", "sp_keys": ["p2"], "deps": {"action": "s1"}},
+            ],
+            "grid": [{"name": "base", "s2": {"p2": [10, 20, 30]}}],
+            "experiment": [
+                {"s1": {"p1": 1}},             # uses all grids → 3 combos
+                {"grids": [], "s1": {"p1": 2}},  # standalone → 1 combo
+            ],
+        }
+    )
+
+    assert len(spec.experiments) == 4
+    standalone = [e for e in spec.experiments if e["s1"]["p1"] == 2]
+    assert len(standalone) == 1
+    assert "s2" not in standalone[0]
+
+
+def test_experiment_unknown_grid_name_raises():
+    with pytest.raises(ConfigValidationError, match="unknown grid 'typo'"):
+        WorkflowSpec.from_mapping(
+            {
+                "actions": [{"name": "s1", "sp_keys": ["p1"]}],
+                "grid": [{"name": "base", "s1": {"p1": [1, 2]}}],
+                "experiment": [{"grids": ["typo"], "s1": {"p1": 99}}],
+            }
+        )
+
+
+def test_grid_unknown_action_raises():
+    with pytest.raises(ConfigValidationError, match="Unnamed grid references unknown action 'typo'"):
+        WorkflowSpec.from_mapping(
+            {
+                "actions": [{"name": "s1", "sp_keys": ["p1"]}],
+                "grid": [{"typo": {"p1": [1, 2]}}],
+            }
+        )
+
+
+def test_experiment_unknown_action_raises():
+    with pytest.raises(ConfigValidationError, match="unknown action 'ghost'"):
+        WorkflowSpec.from_mapping(
+            {
+                "actions": [{"name": "s1", "sp_keys": ["p1"]}],
+                "experiment": [{"ghost": {"p1": 1}}],
+            }
+        )
+
+
 def test_cycle_detection_raises():
     with pytest.raises(ConfigValidationError):
         WorkflowSpec.from_mapping(

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "grubicy"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },
@@ -298,15 +298,11 @@ dev = [
     { name = "mkdocs-autorefs" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
+    { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
 ]
 
 [package.metadata]
@@ -317,6 +313,7 @@ requires-dist = [
     { name = "mkdocs-material", marker = "extra == 'dev'", specifier = ">=9.5.0" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'dev'", specifier = ">=0.25.0" },
     { name = "msgspec", specifier = ">=0.18" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -326,9 +323,6 @@ requires-dist = [
     { name = "tomli-w", specifier = ">=1.0" },
 ]
 provides-extras = ["dev"]
-
-[package.metadata.requires-dev]
-dev = [{ name = "mypy", specifier = ">=1.19.1" }]
 
 [[package]]
 name = "identify"

--- a/uv.lock
+++ b/uv.lock
@@ -282,7 +282,7 @@ wheels = [
 
 [[package]]
 name = "grubicy"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "filelock" },


### PR DESCRIPTION
### Added
- Grid blocks in `pipeline.toml`/`.yaml`: `[[grid]]` sections define parameter sweeps via Cartesian product. List-valued keys are expanded; scalar keys are fixed. Named grids can be referenced selectively from experiment blocks. Grids and experiments are crossed automatically when both are present.
- Grid sweep example in `examples/sweep-example/` with full documentation in `docs/getting-started.md`.

### Fixed
- `get_parent()` now accepts an optional `sp_key` parameter, fixing silent breakage when a `DependencySpec` uses a non-default key.
- `collect_params_with_parents` now raises `DependencyResolutionError` instead of a bare `LookupError` when a parent is missing, consistent with the rest of the library.

### Added
- `ActionSpec.dep_sp_key` property — returns `dependency.sp_key` if a dependency exists, otherwise `DEFAULT_PARENT_SP_KEY`. Centralises parent-key resolution across `collect`, `migrate`, and `row_utils`.
- `RESERVED_DOC_KEYS` is now a public `frozenset` exported from `grubicy`, so callers can filter job document keys without reimplementing the list.